### PR TITLE
feat: add WebSocket connection state to the Session object

### DIFF
--- a/common.go
+++ b/common.go
@@ -13,6 +13,8 @@
 // limitations under the License.
 package ankh
 
+import "crypto/tls"
+
 // CloseConnection will terminate the connection with the client/server
 // application. This handle will be given during the OnConnectedHandler callback
 // and is guaranteed to be thread safe.
@@ -36,4 +38,6 @@ type Session struct {
 	Ping PingMessage
 	// Send will send a binary message to the client/server application.
 	Send SendMessage
+	// ConnectionState contains the TLS connection state.
+	ConnectionState *tls.ConnectionState
 }

--- a/websocket_client_test.go
+++ b/websocket_client_test.go
@@ -132,6 +132,10 @@ func TestWebSocketClient(t *testing.T) {
 			t.Log("obtain server session for further client testing")
 			waitForCapture(t, captorServerSession)
 			serverSession := captorServerSession.Last()
+			if tt.withTLS {
+				require.NotNil(t, serverSession.ConnectionState)
+				require.Equal(t, (uint16(tls.VersionTLS13)), serverSession.ConnectionState.Version)
+			}
 			Verify(serverHandler, Once()).OnConnectionHandler(Any[http.ResponseWriter](), Any[*http.Request]())
 			Verify(serverHandler, Once()).OnConnectedHandler(Exact("client-key"), Any[*ankh.Session]())
 

--- a/websocket_server_test.go
+++ b/websocket_server_test.go
@@ -325,6 +325,17 @@ func TestWebSocketServer(t *testing.T) {
 				client3.cancel()
 				client4.cancel()
 			}()
+			if tt.withTLS {
+				tlsV13 := (uint16(tls.VersionTLS13))
+				require.NotNil(t, captor1Session.Last().ConnectionState)
+				require.Equal(t, tlsV13, captor1Session.Last().ConnectionState.Version)
+				require.NotNil(t, captor2Session.Last().ConnectionState)
+				require.Equal(t, tlsV13, captor2Session.Last().ConnectionState.Version)
+				require.NotNil(t, captor3Session.Last().ConnectionState)
+				require.Equal(t, tlsV13, captor3Session.Last().ConnectionState.Version)
+				require.NotNil(t, captor4Session.Last().ConnectionState)
+				require.Equal(t, tlsV13, captor4Session.Last().ConnectionState.Version)
+			}
 
 			t.Log("verify WebSocket clients connected")
 			Verify(handler1, Times(2)).OnConnectionHandler(Any[http.ResponseWriter](), Any[*http.Request]())


### PR DESCRIPTION
This feature adds the TLS connection state of the established connection on the server to the Session instance that is passed into the OnConnectedHandler().